### PR TITLE
Remove Hobbit::AssetTag module from the application controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class HAT::ApplicationController < HAT::Application
-  include Hobbit::AssetTag
   include Hobbit::Render
   include Hobbit::Session
 


### PR DESCRIPTION
Hi @patriciomacadden, due to Hobbit::AssetTag [has been removed](https://github.com/patriciomacadden/hobbit-contrib/commit/750ecfb47d37dc58450ded1878fbd16777efcf4e) from hobbit-contrib is necessary to remove the requirement of the module in the application controller
