### PR TITLE
Fixes controller require order

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,7 @@ module HAT
   class Application < Hobbit::Base
     Dir[File.join('config', 'initializers', '**/*.rb')].each { |file| require File.expand_path(file) }
 
-    Dir[File.join('app', 'controllers', '**/*.rb')].each { |file| require File.expand_path(file) }
+    controller_files = Dir[File.join('app', 'controllers', '**/*.rb')]
     app_controller = controller_files.detect { |file| file.match %r|application_controller| }
     controller_files.delete(app_controller)
     controller_files.unshift(app_controller)

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,13 @@ Bundler.require :default, ENV['RACK_ENV'].to_sym
 module HAT
   class Application < Hobbit::Base
     Dir[File.join('config', 'initializers', '**/*.rb')].each { |file| require File.expand_path(file) }
+
     Dir[File.join('app', 'controllers', '**/*.rb')].each { |file| require File.expand_path(file) }
+    app_controller = controller_files.detect { |file| file.match %r|application_controller| }
+    controller_files.delete(app_controller)
+    controller_files.unshift(app_controller)
+    controller_files.each { |file| require File.expand_path(file) } 
+
     Dir[File.join('app', 'models', '**/*.rb')].each { |file| require File.expand_path(file) }
 
     use BetterErrors::Middleware if ENV['RACK_ENV'].to_sym == :development


### PR DESCRIPTION
When I copied the template and tried to rack up the app, I found that the RootController was being required before the ApplicationController it requires, causing the following error:

/hat/app/controllers/root_controller.rb:1:in `<top (required)>': uninitialized constant HAT::ApplicationController (NameError)

This fixes the error by assuming the file containing it is named application_controller (couldn't think of a better way), removing it form the array and appending it, so that it gets required first.

Hope it helps!